### PR TITLE
feat(cdk): add sslPolicy to addFargateService

### DIFF
--- a/packages/cdk/src/methods/fargate.ts
+++ b/packages/cdk/src/methods/fargate.ts
@@ -10,7 +10,7 @@ import {
 } from 'aws-cdk-lib/aws-ecs';
 import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
 import { DockerImageAsset } from 'aws-cdk-lib/aws-ecr-assets';
-import { ApplicationProtocol } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
+import { ApplicationProtocol, SslPolicy } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import { RetentionDays } from 'aws-cdk-lib/aws-logs';
 
 import type { MinMaxNumber } from '../types';
@@ -20,7 +20,7 @@ import { DotStack } from '../constructs/Stack';
 import { addBucket } from './s3';
 import { addSecurityGroup } from './security';
 
-export { CpuArchitecture, OperatingSystemFamily };
+export { CpuArchitecture, OperatingSystemFamily, SslPolicy };
 
 export enum ServiceCPUUnits {
   FOUR_VCPU = 4096,
@@ -56,6 +56,7 @@ export interface AddServiceOptions {
   os?: OperatingSystemFamily;
   port?: number;
   scope: DotStack;
+  sslPolicy?: SslPolicy;
   vpc?: IVpc;
 }
 
@@ -85,7 +86,8 @@ export const addFargateService = (options: AddServiceOptions): AddServiceResult 
     nodeMemorySize = 2000,
     os = OperatingSystemFamily.LINUX,
     port = 80,
-    scope
+    scope,
+    sslPolicy
   } = options;
   let { vpc } = options;
   const { env } = scope;
@@ -117,6 +119,7 @@ export const addFargateService = (options: AddServiceOptions): AddServiceResult 
       operatingSystemFamily: os
     },
     serviceName,
+    sslPolicy,
     taskImageOptions: {
       command,
       containerPort: port,


### PR DESCRIPTION
This PR contains a:

- [ ] bugfix
- [x] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes
- [x] no

Breaking Changes?

- [ ] yes
- [x] no

<!-- If yes, then include "BREAKING CHANGES:" in the first commit message body, followed by a description of what is breaking. -->

### Description

This adds an sslPolicy option to the `addFargateService` method

https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_elasticloadbalancingv2.SslPolicy.html
