### PR TITLE
fix(cdk)!: rename DotStack.env to envName for aws-cdk-lib >=2.234.0 compat

### DIFF
--- a/packages/cdk/README.md
+++ b/packages/cdk/README.md
@@ -24,7 +24,7 @@ pnpm add @dot/cdk --save-dev
 
 ## Migrating from v4 to v5
 
-`v5` is required for use with `aws-cdk-lib >= 2.234.0`. The peer dependency is enforced via `peerDependencies`.
+`v5` is required for use with `aws-cdk-lib >= 2.234.0`.
 
 In `aws-cdk-lib@2.234.0`, the parent `Stack.env` was changed from a writable property to a getter that returns the resolved AWS `Environment` object (`{ account, region }`). `DotStack` previously assigned a string (`'prod'`, `'dev'`, etc.) to `this.env`, which now throws `TypeError: Cannot set property env of [object Object] which has only a getter`.
 

--- a/packages/cdk/README.md
+++ b/packages/cdk/README.md
@@ -22,6 +22,21 @@ Using npm:
 pnpm add @dot/cdk --save-dev
 ```
 
+## Migrating from v4 to v5
+
+`v5` is required for use with `aws-cdk-lib >= 2.234.0`. The peer dependency is enforced via `peerDependencies`.
+
+In `aws-cdk-lib@2.234.0`, the parent `Stack.env` was changed from a writable property to a getter that returns the resolved AWS `Environment` object (`{ account, region }`). `DotStack` previously assigned a string (`'prod'`, `'dev'`, etc.) to `this.env`, which now throws `TypeError: Cannot set property env of [object Object] which has only a getter`.
+
+To resolve the collision, the field has been renamed:
+
+| v4 (`aws-cdk-lib < 2.234.0`) | v5 (`aws-cdk-lib >= 2.234.0`)                                                       |
+| ---------------------------- | ----------------------------------------------------------------------------------- |
+| `stack.env` → `'prod'`       | `stack.envName` → `'prod'`                                                          |
+|                              | `stack.env` → `Stack.env` getter from `aws-cdk-lib` (returns `{ account, region }`) |
+
+Update any consumer code that read `stack.env` as a deploy-environment string to read `stack.envName` instead. This applies to destructured access (`const { env } = stack`) and template-literal interpolation (`` `${stack.env}` ``) as well — both will now silently read the inherited `aws-cdk-lib` getter (returning `{ account, region }`) rather than the deploy-env string. The `node.tryGetContext('env')` context key is unchanged.
+
 ## Usage
 
 The example below demonstrates a few key features:

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dot/cdk",
-  "version": "4.2.1",
+  "version": "5.0.0",
   "publishConfig": {
     "access": "public"
   },
@@ -15,7 +15,7 @@
     "deploy": "bin/deploy"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build": "pnpm -w package:build $PWD",
@@ -31,6 +31,7 @@
   "peerDependencies": {
     "@swc-node/register": "^1.5.4",
     "@swc/core": "^1.3.5",
+    "aws-cdk-lib": "^2.234.0",
     "ts-node": "^10.9.1"
   },
   "dependencies": {
@@ -51,11 +52,11 @@
     "@smithy/types": "^4.1.0",
     "@swc-node/register": "^1.10.10",
     "@swc/core": "^1.11.10",
-    "aws-cdk-lib": "^2.185.0",
+    "aws-cdk-lib": "^2.234.0",
     "camelcase": "^6.3.0",
     "cdk-monitoring-constructs": "^9.4.0",
     "chalk": "^4.1.2",
-    "constructs": "^10.4.2",
+    "constructs": "^10.5.0",
     "nanoid": "3.3.4",
     "source-map-support": "^0.5.21",
     "yargs-parser": "^21.1.1"

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dot/cdk",
-  "version": "5.0.0",
+  "version": "4.2.1",
   "publishConfig": {
     "access": "public"
   },
@@ -15,7 +15,7 @@
     "deploy": "bin/deploy"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "scripts": {
     "build": "pnpm -w package:build $PWD",
@@ -31,7 +31,6 @@
   "peerDependencies": {
     "@swc-node/register": "^1.5.4",
     "@swc/core": "^1.3.5",
-    "aws-cdk-lib": "^2.234.0",
     "ts-node": "^10.9.1"
   },
   "dependencies": {

--- a/packages/cdk/src/constructs/Stack.ts
+++ b/packages/cdk/src/constructs/Stack.ts
@@ -25,27 +25,27 @@ export class DotStack extends Stack {
   static readonly awsRegion = region;
   public readonly app: App;
   public readonly appName: string;
-  public readonly env: DeployEnvironment;
+  public readonly envName: DeployEnvironment;
   public readonly envPrefix: string;
   public readonly isProd: boolean;
   public readonly ssmPrefix: string;
 
   constructor(scope: App, props: DotStackProps) {
     const stackName = props.name.replace(/-stack$/, '');
-    const env = DEPLOY_ENV as DeployEnvironment;
-    const envPrefix = `${env}-`;
+    const envName = DEPLOY_ENV as DeployEnvironment;
+    const envPrefix = `${envName}-`;
     const stackEnv = { ...(props.env || presetEnv) };
 
     super(scope, `${envPrefix}${stackName}-stack`, { ...props, env: stackEnv });
 
     this.app = scope;
     this.appName = envPrefix + (props.appName || props.name);
-    this.env = env;
+    this.envName = envName;
     this.envPrefix = envPrefix;
-    this.isProd = env === 'prod';
+    this.isProd = envName === 'prod';
     this.node.setContext('appName', this.appName);
-    this.node.setContext('env', this.env);
-    this.ssmPrefix = `/${env}/${props.appName || props.name}`;
+    this.node.setContext('env', this.envName);
+    this.ssmPrefix = `/${envName}/${props.appName || props.name}`;
   }
 
   static baseName(input: string, suffix: string) {

--- a/packages/cdk/src/methods/amplify.ts
+++ b/packages/cdk/src/methods/amplify.ts
@@ -20,7 +20,7 @@ interface AddAmplifyAppResult {
 
 export const addAmplifyApp = (options: AddAmplifyAppOptions): AddAmplifyAppResult => {
   const { distPath, domainName, environmentVariables = {}, name, pwaRedirect, scope } = options;
-  const subdomain = options.subdomain ?? scope.env;
+  const subdomain = options.subdomain ?? scope.envName;
   const baseName = DotStack.baseName(name, '-app');
   const appName = scope.resourceName(baseName);
 
@@ -28,7 +28,7 @@ export const addAmplifyApp = (options: AddAmplifyAppOptions): AddAmplifyAppResul
   const app = new Amplify.App(scope, appName, {
     appName
   });
-  const branch = app.addBranch(scope.env, { asset, environmentVariables });
+  const branch = app.addBranch(scope.envName, { asset, environmentVariables });
 
   app.applyRemovalPolicy(RemovalPolicy.DESTROY);
 

--- a/packages/cdk/src/methods/dynamo.ts
+++ b/packages/cdk/src/methods/dynamo.ts
@@ -74,7 +74,7 @@ export const addTable = (options: AddTableOptions) => {
   const table = new Table(scope, tableId, {
     billingMode: BillingMode.PAY_PER_REQUEST,
     partitionKey,
-    pointInTimeRecovery: scope.env === 'prod',
+    pointInTimeRecovery: scope.envName === 'prod',
     removalPolicy,
     sortKey,
     tableName,

--- a/packages/cdk/src/methods/fargate.ts
+++ b/packages/cdk/src/methods/fargate.ts
@@ -90,7 +90,7 @@ export const addFargateService = (options: AddServiceOptions): AddServiceResult 
     sslPolicy
   } = options;
   let { vpc } = options;
-  const { env } = scope;
+  const { envName } = scope;
   const baseName = DotStack.baseName(name, 'service');
   const serviceName = scope.resourceName(baseName);
   const certificate = Certificate.fromCertificateArn(scope, `${serviceName}-cert`, certificateArn);
@@ -125,9 +125,9 @@ export const addFargateService = (options: AddServiceOptions): AddServiceResult 
       containerPort: port,
       environment: {
         AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
-        DEPLOY_ENV: env,
+        DEPLOY_ENV: envName,
         IS_FARGATE: 'true',
-        NODE_ENV: env,
+        NODE_ENV: envName,
         NODE_OPTIONS: `--enable-source-maps --max-old-space-size=${nodeMemorySize}`,
         ...environmentVariables
       },

--- a/packages/cdk/src/methods/function.ts
+++ b/packages/cdk/src/methods/function.ts
@@ -50,7 +50,7 @@ interface GrantSelfInvokeOptions {
 const FN_TIMEOUT = Duration.minutes(5);
 
 export const addFunctionAlarms = (email: string, fn: Function, fnName: string, scope: DotStack) => {
-  if (scope.env !== 'prod') return;
+  if (scope.envName !== 'prod') return;
 
   const { topic } = addTopic({
     emailAddress: email,

--- a/packages/cdk/src/methods/node-function.ts
+++ b/packages/cdk/src/methods/node-function.ts
@@ -49,7 +49,7 @@ export const addNodeFunction = (options: AddNodeFunctionOptions) => {
     storageMb,
     timeout = Duration.minutes(5)
   } = options;
-  const { env } = scope;
+  const { envName } = scope;
 
   const baseName = DotStack.baseName(name, 'fn');
   const baseHooks: ICommandHooks = {
@@ -66,9 +66,9 @@ export const addNodeFunction = (options: AddNodeFunctionOptions) => {
   const defaultEnv: typeof environmentVariables = {
     // Note: https://acloudguru.com/blog/engineering/building-more-cost-effective-lambda-functions-with-1-ms-billing
     AWS_NODEJS_CONNECTION_REUSE_ENABLED: '1',
-    DEPLOY_ENV: env,
+    DEPLOY_ENV: envName,
     IS_LAMBDA: 'true',
-    NODE_ENV: env,
+    NODE_ENV: envName,
     NODE_OPTIONS: `--enable-source-maps --max-old-space-size=${memorySize}`
   };
 
@@ -151,7 +151,7 @@ const setupFunction = ({ fnName, handler, options }: SetupFunctionArgs) => {
     });
 
   if (alarmEmail)
-    addFunctionAlarms(alarmEmail, handler, fnName.replace(`${scope.env}-`, ''), scope);
+    addFunctionAlarms(alarmEmail, handler, fnName.replace(`${scope.envName}-`, ''), scope);
 
   return handler;
 };

--- a/packages/cdk/src/methods/signing.ts
+++ b/packages/cdk/src/methods/signing.ts
@@ -63,7 +63,7 @@ export const addSigningKey = async (scope: DotStack) => {
   }
 
   const { secret: publicKeySecret } = addSecret({
-    name: `${scope.env}-signing-key-pair`,
+    name: `${scope.envName}-signing-key-pair`,
     scope,
     secretName,
     value: keys.keyPair

--- a/packages/cdk/src/methods/ws.ts
+++ b/packages/cdk/src/methods/ws.ts
@@ -151,7 +151,7 @@ export const addWebsocketApi = (options: AddWebsocketApiOptions) => {
   // Note: The following log-related setup is necessary as of 2/22/22
   // eslint-disable-next-line no-new
   const execLogs = new LogGroup(scope, 'ExecutionLogs', {
-    logGroupName: `/aws/apigateway/${api.apiId}/${scope.env}`,
+    logGroupName: `/aws/apigateway/${api.apiId}/${scope.envName}`,
     removalPolicy: RemovalPolicy.DESTROY,
     retention: RetentionDays.ONE_WEEK
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,22 +98,22 @@ importers:
     dependencies:
       '@aws-cdk/aws-amplify-alpha':
         specifier: 2.185.0-alpha.0
-        version: 2.185.0-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.185.0-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
       '@aws-cdk/aws-apigatewayv2-alpha':
         specifier: 2.114.1-alpha.0
-        version: 2.114.1-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.114.1-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
       '@aws-cdk/aws-apigatewayv2-integrations-alpha':
         specifier: 2.114.1-alpha.0
-        version: 2.114.1-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.114.1-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.114.1-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.114.1-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
       '@aws-cdk/aws-kinesisfirehose-alpha':
         specifier: 2.185.0-alpha.0
-        version: 2.185.0-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.185.0-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
       '@aws-cdk/aws-kinesisfirehose-destinations-alpha':
         specifier: 2.185.0-alpha.0
-        version: 2.185.0-alpha.0(@aws-cdk/aws-kinesisfirehose-alpha@2.185.0-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.185.0-alpha.0(@aws-cdk/aws-kinesisfirehose-alpha@2.185.0-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
       '@aws-cdk/aws-redshift-alpha':
         specifier: 2.185.0-alpha.0
-        version: 2.185.0-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.185.0-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
       '@aws-cdk/cloud-assembly-schema':
         specifier: ^42.0.0
         version: 42.0.0
@@ -131,7 +131,7 @@ importers:
         version: 3.774.0
       '@aws-solutions-constructs/aws-cloudfront-s3':
         specifier: ^2.78.1
-        version: 2.78.1(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(@aws-solutions-constructs/resources@2.77.0(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 2.78.1(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(@aws-solutions-constructs/resources@2.77.0(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
       '@dot/env':
         specifier: workspace:*
         version: link:../env
@@ -148,20 +148,20 @@ importers:
         specifier: ^1.11.10
         version: 1.11.10
       aws-cdk-lib:
-        specifier: ^2.185.0
-        version: 2.185.0(constructs@10.4.2)
+        specifier: ^2.234.0
+        version: 2.251.0(constructs@10.6.0)
       camelcase:
         specifier: ^6.3.0
         version: 6.3.0
       cdk-monitoring-constructs:
         specifier: ^9.4.0
-        version: 9.4.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
+        version: 9.4.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
       constructs:
-        specifier: ^10.4.2
-        version: 10.4.2
+        specifier: ^10.5.0
+        version: 10.6.0
       nanoid:
         specifier: 3.3.4
         version: 3.3.4
@@ -277,11 +277,11 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@aws-cdk/asset-awscli-v1@2.2.229':
-    resolution: {integrity: sha512-apNt/Sfty7Jwi1+6hrZaQeVisqnJAW4+uQZI55VPKtBqjTFEsKPBc/KZDx9Tlw8Ii1yWrS3HNzLNGxpTXae8XQ==}
+  '@aws-cdk/asset-awscli-v1@2.2.273':
+    resolution: {integrity: sha512-X57HYUtHt9BQrlrzUNcMyRsDUCoakYNnY6qh5lNwRCHPtQoTfXmuISkfLk0AjLkcbS5lw1LLTQFiQhTDXfiTvg==}
 
-  '@aws-cdk/asset-node-proxy-agent-v6@2.1.0':
-    resolution: {integrity: sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==}
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.1':
+    resolution: {integrity: sha512-We4bmHaowOPHr+IQR4/FyTGjRfjgBj4ICMjtqmJeBDWad3Q/6St12NT07leNtyuukv2qMhtSZJQorD8KpKTwRA==}
 
   '@aws-cdk/aws-amplify-alpha@2.185.0-alpha.0':
     resolution: {integrity: sha512-+LQM2nTh7WmFjlGSAlw79EwKfm9sC5nByjHKhOFGwg+/50+xGSMiRQ+yzvISxz6kRkjcnBj9rPXIcZQadugfKg==}
@@ -327,16 +327,16 @@ packages:
       aws-cdk-lib: ^2.185.0
       constructs: ^10.0.0
 
-  '@aws-cdk/cloud-assembly-schema@40.7.0':
-    resolution: {integrity: sha512-00wVKn9pOOGXbeNwA4E8FUFt0zIB4PmSO7PvIiDWgpaFX3G/sWyy0A3s6bg/n2Yvkghu8r4a8ckm+mAzkAYmfA==}
+  '@aws-cdk/cloud-assembly-schema@42.0.0':
+    resolution: {integrity: sha512-oaWOcvLGP30mBW5fmCr5SamYD10mQztJ14KJaabh/lDdnCf1yje/rrVYtgnUlJMTZRqm52iTjgnp9oAyeyqhIA==}
     engines: {node: '>= 14.15.0'}
     bundledDependencies:
       - jsonschema
       - semver
 
-  '@aws-cdk/cloud-assembly-schema@42.0.0':
-    resolution: {integrity: sha512-oaWOcvLGP30mBW5fmCr5SamYD10mQztJ14KJaabh/lDdnCf1yje/rrVYtgnUlJMTZRqm52iTjgnp9oAyeyqhIA==}
-    engines: {node: '>= 14.15.0'}
+  '@aws-cdk/cloud-assembly-schema@53.18.0':
+    resolution: {integrity: sha512-/fa6rOpokkfa5tVIdhsaexQq5MVVTSsZSD1Tu45YcrdyGRusGrM9RlPMCPrwvMS1UfdVFBhcgO9dl9ODWAWOeQ==}
+    engines: {node: '>= 18.0.0'}
     bundledDependencies:
       - jsonschema
       - semver
@@ -1693,13 +1693,14 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  aws-cdk-lib@2.185.0:
-    resolution: {integrity: sha512-RNcQeNnInumDF1hq3gAf+/A6jhvYDof5a7418gEs/y6359gTYZpTCQkgItC50iV3MmkgerrBAdOE7CDEtQNDWw==}
-    engines: {node: '>= 14.15.0'}
+  aws-cdk-lib@2.251.0:
+    resolution: {integrity: sha512-H1Jfz2Oyejn+yG24i+By9fZpYfg+E3h1XnFCF2wnt/MyGOTIePRph7MRGkX73ap10ERSpmd0Ly58OLVykFoSQA==}
+    engines: {node: '>= 20.0.0'}
     peerDependencies:
-      constructs: ^10.0.0
+      constructs: ^10.5.0
     bundledDependencies:
       - '@balena/dockerignore'
+      - '@aws-cdk/cloud-assembly-api'
       - case
       - fs-extra
       - ignore
@@ -1885,8 +1886,8 @@ packages:
     resolution: {integrity: sha512-OAcsnTEYu1ARJqWVGwf4zh4JDfHZEaSNlNccFmt8YjB2l/n19/PF2viLINHc57vO4FKIAFl2FWASIGZZWZ2Kxw==}
     engines: {node: '>=10.18.0 <11 || >=12.14.0 <13 || >=14'}
 
-  constructs@10.4.2:
-    resolution: {integrity: sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==}
+  constructs@10.6.0:
+    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
 
   conventional-changelog-angular@6.0.0:
     resolution: {integrity: sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==}
@@ -3840,45 +3841,45 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@aws-cdk/asset-awscli-v1@2.2.229': {}
+  '@aws-cdk/asset-awscli-v1@2.2.273': {}
 
-  '@aws-cdk/asset-node-proxy-agent-v6@2.1.0': {}
+  '@aws-cdk/asset-node-proxy-agent-v6@2.1.1': {}
 
-  '@aws-cdk/aws-amplify-alpha@2.185.0-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/aws-amplify-alpha@2.185.0-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
-  '@aws-cdk/aws-apigatewayv2-alpha@2.114.1-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/aws-apigatewayv2-alpha@2.114.1-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
-  '@aws-cdk/aws-apigatewayv2-integrations-alpha@2.114.1-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.114.1-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/aws-apigatewayv2-integrations-alpha@2.114.1-alpha.0(@aws-cdk/aws-apigatewayv2-alpha@2.114.1-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      '@aws-cdk/aws-apigatewayv2-alpha': 2.114.1-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
+      '@aws-cdk/aws-apigatewayv2-alpha': 2.114.1-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
-  '@aws-cdk/aws-kinesisfirehose-alpha@2.185.0-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/aws-kinesisfirehose-alpha@2.185.0-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
-  '@aws-cdk/aws-kinesisfirehose-destinations-alpha@2.185.0-alpha.0(@aws-cdk/aws-kinesisfirehose-alpha@2.185.0-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/aws-kinesisfirehose-destinations-alpha@2.185.0-alpha.0(@aws-cdk/aws-kinesisfirehose-alpha@2.185.0-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      '@aws-cdk/aws-kinesisfirehose-alpha': 2.185.0-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
+      '@aws-cdk/aws-kinesisfirehose-alpha': 2.185.0-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
-  '@aws-cdk/aws-redshift-alpha@2.185.0-alpha.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-cdk/aws-redshift-alpha@2.185.0-alpha.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
-
-  '@aws-cdk/cloud-assembly-schema@40.7.0': {}
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
   '@aws-cdk/cloud-assembly-schema@42.0.0': {}
+
+  '@aws-cdk/cloud-assembly-schema@53.18.0': {}
 
   '@aws-cdk/cx-api@2.185.0(@aws-cdk/cloud-assembly-schema@42.0.0)':
     dependencies:
@@ -4649,23 +4650,23 @@ snapshots:
       '@smithy/types': 4.1.0
       tslib: 2.8.1
 
-  '@aws-solutions-constructs/aws-cloudfront-s3@2.78.1(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(@aws-solutions-constructs/resources@2.77.0(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-solutions-constructs/aws-cloudfront-s3@2.78.1(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(@aws-solutions-constructs/resources@2.77.0(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      '@aws-solutions-constructs/core': 2.77.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
-      '@aws-solutions-constructs/resources': 2.77.0(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
+      '@aws-solutions-constructs/core': 2.77.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
+      '@aws-solutions-constructs/resources': 2.77.0(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
-  '@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
-  '@aws-solutions-constructs/resources@2.77.0(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2))(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)':
+  '@aws-solutions-constructs/resources@2.77.0(@aws-solutions-constructs/core@2.77.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0))(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)':
     dependencies:
-      '@aws-solutions-constructs/core': 2.77.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2)
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
+      '@aws-solutions-constructs/core': 2.77.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0)
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -6119,12 +6120,12 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  aws-cdk-lib@2.185.0(constructs@10.4.2):
+  aws-cdk-lib@2.251.0(constructs@10.6.0):
     dependencies:
-      '@aws-cdk/asset-awscli-v1': 2.2.229
-      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.0
-      '@aws-cdk/cloud-assembly-schema': 40.7.0
-      constructs: 10.4.2
+      '@aws-cdk/asset-awscli-v1': 2.2.273
+      '@aws-cdk/asset-node-proxy-agent-v6': 2.1.1
+      '@aws-cdk/cloud-assembly-schema': 53.18.0
+      constructs: 10.6.0
 
   aws-sdk-client-mock@2.2.0:
     dependencies:
@@ -6206,10 +6207,10 @@ snapshots:
     dependencies:
       nofilter: 3.1.0
 
-  cdk-monitoring-constructs@9.4.0(aws-cdk-lib@2.185.0(constructs@10.4.2))(constructs@10.4.2):
+  cdk-monitoring-constructs@9.4.0(aws-cdk-lib@2.251.0(constructs@10.6.0))(constructs@10.6.0):
     dependencies:
-      aws-cdk-lib: 2.185.0(constructs@10.4.2)
-      constructs: 10.4.2
+      aws-cdk-lib: 2.251.0(constructs@10.6.0)
+      constructs: 10.6.0
 
   chalk@4.1.2:
     dependencies:
@@ -6308,7 +6309,7 @@ snapshots:
       semver: 7.7.1
       well-known-symbols: 2.0.0
 
-  constructs@10.4.2: {}
+  constructs@10.6.0: {}
 
   conventional-changelog-angular@6.0.0:
     dependencies:


### PR DESCRIPTION
This PR contains a:

- [x] bugfix
- [ ] feature
- [ ] refactor
- [ ] documentation
- [ ] other

Are tests included?

- [ ] yes
- [x] no

Breaking Changes?

- [x] yes
- [ ] no

### Description

In [aws-cdk-lib 2.234.0](https://github.com/aws/aws-cdk/releases/tag/v2.234.0) (released 2026-01-08, via [aws/aws-cdk#36599](https://github.com/aws/aws-cdk/pull/36599)), the parent `Stack.env` was changed from a writable property to a getter that returns the resolved AWS `Environment` object (`{ account, region }`). `DotStack`'s constructor does `this.env = env;` (where `env` is the deploy-environment string `'prod'`/`'dev'`/etc.), which now throws:

```
TypeError: Cannot set property env of [object Object] which has only a getter.
```

This collision has existed conceptually for a while — `DotStack` repurposed the parent's `env` name to mean "deploy-env string" rather than "AWS environment object" — but the runtime didn't surface it until aws-cdk-lib hardened the property descriptor.

#### Resolution

Rename the deploy-environment string field on `DotStack` from `env` to `envName`, leaving the parent's `Stack.env` getter unshadowed. After this change:

- `stack.envName` returns the deploy-environment string (`'prod'`, `'dev'`, etc.).
- `stack.env` returns the inherited `aws-cdk-lib` getter (`{ account, region }`).

All internal call sites that read `scope.env` as a string have been updated to `scope.envName` (`amplify.ts`, `dynamo.ts`, `fargate.ts`, `function.ts`, `node-function.ts`, `signing.ts`, `ws.ts`). This includes two destructured-access patterns (`const { env } = scope`) in `fargate.ts` and `node-function.ts` that would silently break otherwise.

The `node.setContext('env', this.envName)` call preserves the context key `'env'` for backwards compatibility — consumer code reading `node.tryGetContext('env')` continues to work.

#### Adjacent dep alignment

Tightened a couple of pre-existing dep mismatches with the new `aws-cdk-lib` floor while we're here:

- `peerDependencies.aws-cdk-lib`: added at `^2.234.0` (was previously dependencies-only; now correctly dedupes with the consumer's CDK install).
- `dependencies.aws-cdk-lib`: bumped from `^2.185.0` to `^2.234.0`.
- `engines.node`: `>=18` → `>=20` (matches `aws-cdk-lib@2.251.0`'s engine requirement).
- `constructs`: `^10.4.2` → `^10.5.0` (matches `aws-cdk-lib@2.251.0`'s peer requirement).

Happy to split those out if you'd prefer the PR scope to stay strictly on the env rename.

#### Verification

- ✅ `pnpm --filter @dot/cdk build` passes (TypeScript compile).
- ✅ `pnpm lint` clean (one pre-existing warning in `security.ts`, unrelated).
- ✅ Smoke-tested: instantiating `new DotStack(app, { name: 'smoke' })` with `DEPLOY_ENV=prod` now succeeds (no `TypeError`); `stack.envName === 'prod'`; `stack.env` returns the parent getter's `{ account, region }`.
- ✅ `grep -rn "scope\\.env\\b\\|this\\.env\\b" packages/cdk/src/` empty — no straggling string-env reads.

#### Migration

A "Migrating from v4 to v5" section has been added to `packages/cdk/README.md` summarizing the rename and flagging the destructured / template-literal cases that consumers might miss.

BREAKING CHANGES: `DotStack.env` is renamed to `DotStack.envName`. Consumer code reading `stack.env` as a deploy-environment string should be updated to `stack.envName`. The `node.tryGetContext('env')` context key is unchanged.