### PR TITLE
feat(cdk): forward awslogs driver options on addFargateService

### DIFF
--- a/packages/cdk/src/methods/fargate.ts
+++ b/packages/cdk/src/methods/fargate.ts
@@ -1,6 +1,7 @@
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import { InterfaceVpcEndpointAwsService, Vpc, type IVpc } from 'aws-cdk-lib/aws-ec2';
 import {
+  type AwsLogDriverProps,
   ContainerImage,
   CpuArchitecture,
   LogDriver,
@@ -39,6 +40,7 @@ export enum ServiceMemoryLimit {
 export interface AddServiceOptions {
   architecture?: CpuArchitecture;
   assignPublicIp?: boolean;
+  awslogs?: Partial<AwsLogDriverProps>;
   baseDir: string;
   certificateArn: string;
   command?: string[];
@@ -70,6 +72,7 @@ export const addFargateService = (options: AddServiceOptions): AddServiceResult 
   const {
     architecture = CpuArchitecture.ARM64,
     assignPublicIp = true,
+    awslogs,
     baseDir,
     certificateArn,
     command,
@@ -135,7 +138,8 @@ export const addFargateService = (options: AddServiceOptions): AddServiceResult 
       image,
       logDriver: LogDriver.awsLogs({
         logRetention: RetentionDays.ONE_WEEK,
-        streamPrefix: serviceName
+        streamPrefix: serviceName,
+        ...awslogs
       })
     },
     vpc

--- a/packages/cdk/src/methods/fargate.ts
+++ b/packages/cdk/src/methods/fargate.ts
@@ -40,7 +40,7 @@ export enum ServiceMemoryLimit {
 export interface AddServiceOptions {
   architecture?: CpuArchitecture;
   assignPublicIp?: boolean;
-  awslogs?: Partial<AwsLogDriverProps>;
+  awsLogs?: Partial<AwsLogDriverProps>;
   baseDir: string;
   certificateArn: string;
   command?: string[];
@@ -72,7 +72,7 @@ export const addFargateService = (options: AddServiceOptions): AddServiceResult 
   const {
     architecture = CpuArchitecture.ARM64,
     assignPublicIp = true,
-    awslogs,
+    awsLogs,
     baseDir,
     certificateArn,
     command,
@@ -137,9 +137,11 @@ export const addFargateService = (options: AddServiceOptions): AddServiceResult 
       family: `${serviceName}-task-def`,
       image,
       logDriver: LogDriver.awsLogs({
-        logRetention: RetentionDays.ONE_WEEK,
         streamPrefix: serviceName,
-        ...awslogs
+        // CDK throws if both `logGroup` and `logRetention` are set; skip the
+        // default when caller supplies their own log group.
+        ...(!awsLogs?.logGroup && { logRetention: RetentionDays.ONE_WEEK }),
+        ...awsLogs
       })
     },
     vpc


### PR DESCRIPTION
## Summary

Adds an `awslogs?: Partial<AwsLogDriverProps>` option to `addFargateService`. The provided options are spread into the underlying `LogDriver.awsLogs(...)` call after the function-side defaults (`streamPrefix: <serviceName>`, `logRetention: ONE_WEEK`), so callers can override anything CDK exposes without losing the defaults.

## Motivation

Currently the only path to tune awslogs driver options (most often `mode: NON_BLOCKING` and `maxBufferSize` for high-volume Node.js services where stdout backpressure can stall the event loop — see [AWS's blog post](https://aws.amazon.com/blogs/containers/preventing-log-loss-with-non-blocking-mode-in-the-awslogs-container-log-driver/)) is to reach past `addFargateService` and call `addPropertyOverride` on the L1 `CfnTaskDefinition`. That's noisy, untyped, and breaks if the L2 internals change.

## Usage

```ts
import { AwsLogDriverMode } from 'aws-cdk-lib/aws-ecs';
import { Size } from 'aws-cdk-lib';

addFargateService({
  // ...
  awslogs: {
    mode: AwsLogDriverMode.NON_BLOCKING,
    maxBufferSize: Size.mebibytes(4),
  },
});
```

`Partial<AwsLogDriverProps>` means callers can also tune `multilinePattern`, `datetimeFormat`, `logRetention`, etc., or override the function-side `streamPrefix` if they really want to.

## Compatibility

Backwards compatible — `awslogs` is optional. Existing callers see no behavior change. CDK validates `maxBufferSize` requires `mode: NON_BLOCKING` at synth time, so misuse fails loudly.